### PR TITLE
Adding additional error handling

### DIFF
--- a/src/utils/form-ui.ts
+++ b/src/utils/form-ui.ts
@@ -410,6 +410,9 @@ export async function mapFormModelWithData(
             children = await partsFields(children, { fieldObject, property, podUri, value })
 
             // TODO: Remove the dependency on lodash by adding a custom deep clone function
+            if (!children[UI.PART]) {
+              throw new Error('Error rendering Form Model - Multiple has no part property')
+            }
             const objectKey = Object.keys(children[UI.PART])
             children[UI.CLONE_PARTS] = cloneDeep(children[UI.PART][objectKey[0]][UI.PARTS])
             cleanClonePartData(children)


### PR DESCRIPTION
As a result of the change from ui:parts to ui:part for Multiple fields in the Form Language definition, more errors in Form Models are likely to occur. This change is to handle the case where a Multiple without a part defined is an invalid Form Model, and exit the function early.