### PR TITLE
Adding support for i18n in form renderer

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -109,6 +109,7 @@ export const NS = {
   UI: {
     TimeField: `${nsBase}TimeField`,
     MultipleField: `${nsBase}Multiple`,
-    GroupField: `${nsBase}Group`
+    GroupField: `${nsBase}Group`,
+    Label: `${nsBase}label`
   }
 }

--- a/src/utils/form-ui.ts
+++ b/src/utils/form-ui.ts
@@ -101,7 +101,7 @@ async function getPropertyValue(field: string, property: string, lang: string = 
   // This is  the recommended way of fetching languages until a more permanent solution is implemented in ldflex
   if (property === NS.UI.Label) {
     let labelValue = ''
-    for await (const label of data.from(updatedProperty)[field][property]) {
+    for await (const label of data.from(updatedProperty)[field][NS.UI.Label]) {
       if (label && label.language === lang) {
         labelValue = label.value
       }
@@ -188,7 +188,6 @@ async function turtleToFormUi(document: any, language: string) {
     ) {
       const label = await findLabel(fields[subjectPrefix][UI.PROPERTY])
       fields = { ...fields, [subjectPrefix]: { ...fields[subjectPrefix], [UI.LABEL]: label } }
-    } else if (fields[subjectPrefix] && fields[subjectPrefix][UI.LABEL]) {
     }
   }
   return fields

--- a/src/utils/form-ui.ts
+++ b/src/utils/form-ui.ts
@@ -89,6 +89,8 @@ function getPredicateName(predicate: string): any {
 
 /**
  * Fetch a value for a given subject and property, with special considerations for specific properties
+ * The fetch will look for language strings first and if no language is available it will fall back to the non-language string
+ * It also calls loopList for ui#values, which is a dropdown, and concerts the rdf list into a JS array
  * @param field
  * @param property
  * @param lang
@@ -98,7 +100,8 @@ async function getPropertyValue(field: string, property: string, lang: string = 
   const updatedProperty = changeHostProtocol(field)
 
   // For labels, loop over the values of the property. If there are multiple language values they will be returned here in the for await
-  // This is  the recommended way of fetching languages until a more permanent solution is implemented in ldflex
+  // This is the recommended way of fetching languages until a more permanent solution is implemented in ldflex
+  // Issue Reference: https://github.com/LDflex/LDflex/issues/47
   if (property === NS.UI.Label) {
     let labelValue = ''
     for await (const label of data.from(updatedProperty)[field][NS.UI.Label]) {


### PR DESCRIPTION
Added a new constant value for labels, and updated the generic property fetch to have special cases for labels.

The for await loop is currently the suggested way to get a language value using ldflex, until a more permanent solution is implemented.